### PR TITLE
Fix execution when current folder is not script folder

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-source ./lib/selenium.sh
+
+# Resolve location of current script, in case it's executed from another folder.
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+source "${SCRIPT_DIR}/lib/selenium.sh"
 
 main() {
     # Open the page.

--- a/demo2.sh
+++ b/demo2.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-source ./lib/selenium.sh --headless
+
+# Resolve location of current script, in case it's executed from another folder.
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+source "${SCRIPT_DIR}/lib/selenium.sh" --headless
 
 main() {
     screen_clear

--- a/lib/selenium.sh
+++ b/lib/selenium.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-source ./lib/util.sh
-source ./lib/core.sh
+
+# Resolve location of current script, in case it's executed from another folder.
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+source "${SCRIPT_DIR}/util.sh"
+source "${SCRIPT_DIR}/core.sh"
 
 init() {
   local sessionId=$(new_session $@)


### PR DESCRIPTION
If demo scripts were called from another folder it was failing to source the selenium.sh script, e.g. `bash shellnium/demo.sh`.

Fix that by resolving current script location and sourcing with absolute path.