### PR TITLE
Add headless mode support via SHELLNIUM_HEADLESS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,44 @@ ChromeDriver is automatically downloaded to `~/.cache/shellnium/` and started on
 
 | Environment Variable | Default | Description |
 |---|---|---|
+| `SHELLNIUM_HEADLESS` | (unset) | Set to `true` or `1` to enable headless mode (no visible browser window) |
 | `SHELLNIUM_DRIVER_URL` | `http://localhost:9515` | Custom ChromeDriver URL (disables auto-setup) |
 | `SHELLNIUM_PORT` | `9515` | Port for auto-started ChromeDriver |
 | `SHELLNIUM_CACHE_DIR` | `~/.cache/shellnium` | Cache directory for downloaded ChromeDriver |
+
+### Headless Mode
+
+Headless mode runs Chrome without a visible browser window, which is essential for CI/CD pipelines and server-side automation.
+
+```bash
+# Enable headless mode via environment variable
+SHELLNIUM_HEADLESS=true bash demo.sh
+
+# Or export it for the entire session
+export SHELLNIUM_HEADLESS=true
+bash demo.sh
+```
+
+You can also pass `--headless` directly as a Chrome option (e.g., `bash demo.sh --headless`), but the environment variable is recommended for CI/CD environments.
+
+#### GitHub Actions Example
+
+```yaml
+name: Browser Automation
+on: [push]
+
+jobs:
+  automate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get install -y jq unzip google-chrome-stable
+      - name: Run automation script
+        env:
+          SHELLNIUM_HEADLESS: true
+        run: bash demo.sh
+```
 
 ## Examples
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -55,6 +55,11 @@ new_session() {
     "--window-size=1920,1080"
     "$@"
   )
+
+  # Append headless flag when SHELLNIUM_HEADLESS is enabled
+  if [ "${SHELLNIUM_HEADLESS}" = "true" ] || [ "${SHELLNIUM_HEADLESS}" = "1" ]; then
+    allArgs+=("--headless=new")
+  fi
   chromeOptions=$(for i in "${allArgs[@]}"; do printf '"%s",' "${i}"; done | sed 's/,$//')
   _POST -d '{
     "desiredCapabilities": {


### PR DESCRIPTION
## What does this PR do?

Adds support for running Chrome in headless mode through the `SHELLNIUM_HEADLESS` environment variable. This is essential for CI/CD pipelines and server-side automation where a visible browser window is not needed or available.

### Changes:
- **lib/core.sh**: Added logic to append `--headless=new` flag to Chrome options when `SHELLNIUM_HEADLESS` is set to `true` or `1`
- **README.md**: 
  - Added `SHELLNIUM_HEADLESS` to the environment variables table
  - Added comprehensive "Headless Mode" section with usage examples
  - Included GitHub Actions example demonstrating CI/CD integration

### How it works:
Users can now enable headless mode by setting the environment variable before running their automation scripts:
```bash
SHELLNIUM_HEADLESS=true bash demo.sh
```

## Checklist
- [ ] Tested with `bash` and `zsh`
- [ ] Variables are properly quoted
- [ ] No debug output (e.g., stray `echo` statements)

https://claude.ai/code/session_01SpeL1KqMKxQm7RNYjM6v6e