### PR TITLE
Add Docker support for easy trial and CI usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.claude
+*.md
+!README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+    branches: [master]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test image
+        run: |
+          docker build -t shellnium-test .
+          docker run --rm --shm-size=2g shellnium-test demo.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:bookworm-slim
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    curl \
+    jq \
+    unzip \
+    ca-certificates \
+    gnupg \
+    git \
+    shellcheck \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install bats-core
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core \
+    && /tmp/bats-core/install.sh /usr/local \
+    && rm -rf /tmp/bats-core
+
+# Install Chromium (supports both amd64 and arm64)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium chromium-driver \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy shellnium
+WORKDIR /opt/shellnium
+COPY lib/ ./lib/
+COPY tests/ ./tests/
+COPY demo.sh demo2.sh demo3.sh ./
+
+# Copy entrypoint
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Default to headless mode in container
+ENV SHELLNIUM_CHROME_OPTS="--headless --no-sandbox --disable-dev-shm-usage --disable-gpu"
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["demo.sh"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,38 @@ sudo pacman -S jq unzip
 bash demo.sh
 ```
 
+### Docker
+
+Run Shellnium instantly without installing Chrome or ChromeDriver locally:
+
+```bash
+# Run the demo
+docker run --rm --shm-size=2g ghcr.io/rasukarusan/shellnium demo.sh
+
+# Run your own script
+docker run --rm --shm-size=2g -v ./my_script.sh:/app/my_script.sh ghcr.io/rasukarusan/shellnium my_script.sh
+
+# Using docker compose
+docker compose run --rm shellnium
+```
+
+Or build locally:
+
+```bash
+docker build -t shellnium .
+docker run --rm --shm-size=2g shellnium demo.sh
+```
+
+You can also run ShellCheck and unit tests inside the container:
+
+```bash
+# Run ShellCheck on library files
+docker run --rm shellnium shellcheck
+
+# Run unit tests (bats)
+docker run --rm shellnium test
+```
+
 You can pass Chrome options like `--headless`:
 ```sh
 bash demo.sh --headless --lang=es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  shellnium:
+    build: .
+    # Mount custom scripts into /app
+    volumes:
+      - ./:/app:ro
+    # Override CMD to run a specific script
+    # command: ["my_script.sh"]
+    environment:
+      - SHELLNIUM_CHROME_OPTS=--headless --no-sandbox --disable-dev-shm-usage --disable-gpu
+    # Increase shared memory for Chrome
+    shm_size: '2gb'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+CMD="${1:-demo.sh}"
+shift 2>/dev/null || true
+
+# Run bats tests
+if [ "$CMD" = "test" ] || [ "$CMD" = "bats" ]; then
+    exec bats /opt/shellnium/tests/ "$@"
+fi
+
+# Run shellcheck
+if [ "$CMD" = "shellcheck" ] || [ "$CMD" = "lint" ]; then
+    exec shellcheck -s bash /opt/shellnium/lib/*.sh "$@"
+fi
+
+# If the script path is not absolute, look for it in /opt/shellnium or /app
+if [[ "$CMD" != /* ]]; then
+    if [ -f "/opt/shellnium/$CMD" ]; then
+        CMD="/opt/shellnium/$CMD"
+    elif [ -f "/app/$CMD" ]; then
+        CMD="/app/$CMD"
+    fi
+fi
+
+if [ ! -f "$CMD" ]; then
+    echo "Error: Script not found: $CMD" >&2
+    exit 1
+fi
+
+# Pass SHELLNIUM_CHROME_OPTS as Chrome flags and any extra arguments
+echo "[shellnium] Running: $(basename "$CMD")"
+bash "$CMD" $SHELLNIUM_CHROME_OPTS "$@"
+echo "[shellnium] Done (exit code: $?)"


### PR DESCRIPTION
 ## Summary
  - Add Dockerfile (debian:bookworm-slim + Chromium) to run Shellnium without local setup
  - Support `docker run --rm shellnium test` / `shellcheck` to run tests and lint inside the container
  - Add GitHub Actions workflow for auto build & publish to ghcr.io
  - Add Docker Quick Start section to README

  Closes #33

  ## Test plan
  - [x] `docker build` succeeds
  - [x] `docker run --rm --shm-size=2g shellnium demo.sh` runs the demo
  - [x] `docker run --rm shellnium test` passes all bats tests
  - [x] `docker run --rm shellnium shellcheck` passes lint
